### PR TITLE
开启由docker-compose.yml启动的容器有访问外网的能力

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
         - config:/etc/gitlab
         - data:/var/opt/gitlab
         - logs:/var/log/gitlab
+      network_mode: host
 volumes:
     config:
     data:


### PR DESCRIPTION
这样配置的docker gitlab才能发送邮件